### PR TITLE
Add automated Docker Hub publishing with GitHub Actions

### DIFF
--- a/.github/DOCKER_HUB_SETUP.md
+++ b/.github/DOCKER_HUB_SETUP.md
@@ -1,0 +1,135 @@
+# Docker Hub Setup for Automated Image Publishing
+
+This repository is configured to automatically build and push Docker images to Docker Hub using GitHub Actions.
+
+## Prerequisites
+
+1. A Docker Hub account
+2. Repository admin access to configure GitHub secrets
+
+## Setup Instructions
+
+### 1. Create a Docker Hub Access Token
+
+1. Log in to [Docker Hub](https://hub.docker.com/)
+2. Click on your username in the top right corner
+3. Select **Account Settings** → **Security**
+4. Click **New Access Token**
+5. Give it a description (e.g., "GitHub Actions - newrelic_exporter")
+6. Set the access permissions to **Read, Write, Delete** (or at minimum **Read, Write**)
+7. Click **Generate**
+8. **Important:** Copy the token immediately - you won't be able to see it again!
+
+### 2. Add GitHub Secrets
+
+1. Go to your GitHub repository
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Add the following secrets:
+
+   **DOCKERHUB_USERNAME**
+   - Value: Your Docker Hub username
+
+   **DOCKERHUB_TOKEN**
+   - Value: The access token you generated in step 1
+
+### 3. Verify the Workflow
+
+Once the secrets are configured, the workflow will automatically:
+
+- **On push to `main` or `master` branch:**
+  - Build the Docker image
+  - Push it to Docker Hub with the `latest` tag
+  - Tag it with the branch name and git SHA
+
+- **On git tags (e.g., `v1.0.0`):**
+  - Build the Docker image
+  - Push it with semantic version tags:
+    - `1.0.0` (exact version)
+    - `1.0` (major.minor)
+    - `1` (major)
+    - `latest` (if pushed to default branch)
+
+- **On pull requests:**
+  - Build the Docker image (but do not push)
+  - Validate that the Docker build succeeds
+
+### 4. Testing the Setup
+
+To test the setup:
+
+1. Make a commit to the `main` or `master` branch
+2. Go to the **Actions** tab in GitHub
+3. Watch the "Docker Build and Push" workflow run
+4. Once complete, check your Docker Hub repository for the new image
+
+### 5. Creating Releases
+
+To create a versioned release:
+
+```bash
+# Tag the commit
+git tag -a v1.0.0 -m "Release version 1.0.0"
+
+# Push the tag
+git push origin v1.0.0
+```
+
+This will trigger the workflow and create multiple version tags on Docker Hub.
+
+## Workflow Features
+
+- **Multi-architecture builds:** Builds for both `linux/amd64` and `linux/arm64`
+- **Build caching:** Uses GitHub Actions cache to speed up builds
+- **Automatic tagging:** Smart tagging based on branches, PRs, and git tags
+- **Security:** Uses Docker Hub access tokens (not passwords)
+
+## Updating the Docker Image Name
+
+If you need to change the Docker Hub repository name, edit `.github/workflows/docker-publish.yml`:
+
+```yaml
+env:
+  IMAGE_NAME: your-dockerhub-username/your-repository-name
+```
+
+## Troubleshooting
+
+### Error: "unauthorized: authentication required"
+
+- Verify that `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are set correctly
+- Check that the access token has the correct permissions
+- Ensure the token hasn't expired
+
+### Build fails
+
+- Check the Actions tab for detailed error logs
+- Verify the Dockerfile is valid: `docker build -t test .`
+- Ensure all dependencies are available
+
+### Image not appearing on Docker Hub
+
+- Verify you're not building from a pull request (PRs don't push)
+- Check that you're pushing to the correct branch (main/master)
+- Verify the Docker Hub repository exists or that you have permissions to create it
+
+## Manual Docker Build and Push
+
+If you need to manually build and push:
+
+```bash
+# Build the image
+docker build -t mrf/newrelic-exporter:latest .
+
+# Log in to Docker Hub
+docker login
+
+# Push the image
+docker push mrf/newrelic-exporter:latest
+```
+
+## Additional Resources
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [Docker Hub Access Tokens](https://docs.docker.com/docker-hub/access-tokens/)
+- [Docker Build Push Action](https://github.com/docker/build-push-action)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+      - master
+  release:
+    types: [published]
+
+env:
+  # Docker Hub repository name
+  IMAGE_NAME: mrf/newrelic-exporter
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag with 'latest' on default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # Tag with git tag (v1.0.0 -> 1.0.0)
+            type=semver,pattern={{version}}
+            # Tag with major.minor (v1.0.0 -> 1.0)
+            type=semver,pattern={{major}}.{{minor}}
+            # Tag with major version (v1.0.0 -> 1)
+            type=semver,pattern={{major}}
+            # Tag with git short SHA
+            type=sha,prefix={{branch}}-
+            # Tag with branch name for non-main branches
+            type=ref,event=branch
+            # Tag with PR number
+            type=ref,event=pr
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          # Only push if not a PR (build only for PRs)
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Image digest
+        run: echo "Image pushed with tags:  ${{ steps.meta.outputs.tags }}"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Prometheus exporter for New Relic data.
 Requires a New Relic account.
+
+## Docker Hub
+
+Pre-built Docker images are automatically published to Docker Hub:
+- **Latest stable:** `docker pull mrf/newrelic-exporter:latest`
+- **Specific version:** `docker pull mrf/newrelic-exporter:1.0.0`
+
+Docker images are automatically built and published on every release using GitHub Actions.
+
 ## Building and running
 
 ### Running in a container


### PR DESCRIPTION
This commit sets up automated Docker image building and publishing to Docker Hub using GitHub Actions.

Changes:
1. Added GitHub Actions workflow (.github/workflows/docker-publish.yml)
   - Automatically builds Docker images on push to main/master
   - Publishes to Docker Hub with proper versioning
   - Supports semantic versioning tags (v1.0.0 -> 1.0.0, 1.0, 1)
   - Builds multi-architecture images (amd64, arm64)
   - Uses build caching for faster builds
   - Only builds (doesn't push) on pull requests

2. Added comprehensive setup documentation
   - Step-by-step guide for Docker Hub token creation
   - Instructions for configuring GitHub secrets
   - Troubleshooting section
   - Manual build/push instructions

3. Updated README.md
   - Added Docker Hub section with pull commands
   - Noted automatic publishing on releases

The workflow triggers on:
- Pushes to main/master branches (tags with 'latest')
- Git tags matching v*.*.* pattern (creates version tags)
- Pull requests (build only, no push)

Required GitHub secrets:
- DOCKERHUB_USERNAME: Docker Hub username
- DOCKERHUB_TOKEN: Docker Hub access token

Resolves: newrelic_exporter-bnp (Push image to dockerhub)