### PR TITLE
Fix silent config failures and add validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/prometheus/log"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
@@ -42,10 +43,61 @@ func GetConfig(path string) (Config, error) {
 
 	err = yaml.Unmarshal(configSource, &config)
 	if err != nil {
-		return config, err
+		return config, fmt.Errorf("failed to parse YAML config: %w", err)
+	}
+
+	err = config.Validate()
+	if err != nil {
+		return config, fmt.Errorf("config validation failed: %w", err)
 	}
 
 	log.Debugf("Config loaded: %v", config)
 
-	return config, err
+	return config, nil
+}
+
+// Validate checks if the configuration is valid and provides helpful error messages
+func (c *Config) Validate() error {
+	// Check required fields
+	if c.NRApiKey == "" {
+		return fmt.Errorf("api.key is required but not set")
+	}
+
+	if c.NRService == "" {
+		return fmt.Errorf("api.service is required but not set (e.g., 'applications', 'mobile')")
+	}
+
+	if len(c.NRMetricFilters) == 0 {
+		return fmt.Errorf("api.include-metric-filters is required but empty - at least one metric filter must be specified")
+	}
+
+	// Check duration fields - if they're 0, it might indicate parsing failure
+	// YAML duration parsing expects proper units like "15s", "1h", "30m"
+	if c.NRTimeout == 0 {
+		return fmt.Errorf("api.timeout is not set or invalid - please specify a duration with units (e.g., '15s', '30s')")
+	}
+
+	// Warn about potentially incorrect duration values (less than 1 second suggests missing units)
+	if c.NRTimeout < time.Second {
+		log.Warnf("api.timeout is set to %v which is less than 1 second - did you forget to add time units? (e.g., '15s' instead of '15')", c.NRTimeout)
+	}
+
+	// Set defaults for optional fields
+	if c.NRApiServer == "" {
+		c.NRApiServer = "https://api.newrelic.com"
+	}
+
+	if c.MetricPath == "" {
+		c.MetricPath = "/metrics"
+	}
+
+	if c.ListenAddress == "" {
+		c.ListenAddress = ":9126"
+	}
+
+	if c.NRPeriod == 0 {
+		c.NRPeriod = 60
+	}
+
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConfigValidation_MissingAPIKey(t *testing.T) {
+	configContent := `
+api.server: https://api.newrelic.com
+api.timeout: 15s
+api.service: applications
+api.include-metric-filters:
+  - HttpDispatcher
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	_, err := GetConfig(tmpfile)
+	if err == nil {
+		t.Fatal("Expected error for missing API key, got nil")
+	}
+	if !strings.Contains(err.Error(), "api.key") {
+		t.Errorf("Expected error message to mention 'api.key', got: %v", err)
+	}
+}
+
+func TestConfigValidation_MissingService(t *testing.T) {
+	configContent := `
+api.key: test-key-123
+api.timeout: 15s
+api.include-metric-filters:
+  - HttpDispatcher
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	_, err := GetConfig(tmpfile)
+	if err == nil {
+		t.Fatal("Expected error for missing service, got nil")
+	}
+	if !strings.Contains(err.Error(), "api.service") {
+		t.Errorf("Expected error message to mention 'api.service', got: %v", err)
+	}
+}
+
+func TestConfigValidation_MissingMetricFilters(t *testing.T) {
+	configContent := `
+api.key: test-key-123
+api.timeout: 15s
+api.service: applications
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	_, err := GetConfig(tmpfile)
+	if err == nil {
+		t.Fatal("Expected error for missing metric filters, got nil")
+	}
+	if !strings.Contains(err.Error(), "api.include-metric-filters") {
+		t.Errorf("Expected error message to mention 'api.include-metric-filters', got: %v", err)
+	}
+}
+
+func TestConfigValidation_MissingTimeoutUnit(t *testing.T) {
+	configContent := `
+api.key: test-key-123
+api.service: applications
+api.timeout: 15
+api.include-metric-filters:
+  - HttpDispatcher
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	_, err := GetConfig(tmpfile)
+	// YAML will parse "15" as 15 nanoseconds, which is less than 1 second
+	// Our validation should catch this
+	if err == nil {
+		t.Fatal("Expected error or warning for timeout without units, got nil")
+	}
+}
+
+func TestConfigValidation_MissingTimeout(t *testing.T) {
+	configContent := `
+api.key: test-key-123
+api.service: applications
+api.include-metric-filters:
+  - HttpDispatcher
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	_, err := GetConfig(tmpfile)
+	if err == nil {
+		t.Fatal("Expected error for missing timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "api.timeout") {
+		t.Errorf("Expected error message to mention 'api.timeout', got: %v", err)
+	}
+}
+
+func TestConfigValidation_ValidConfig(t *testing.T) {
+	configContent := `
+api.key: test-key-123
+api.server: https://api.newrelic.com
+api.timeout: 15s
+api.period: 60
+api.service: applications
+api.apps-list-cache-time: 1h
+api.metric-names-cache-time: 1h
+api.include-metric-filters:
+  - HttpDispatcher
+  - Database
+web.listen-address: ":9126"
+web.telemetry-path: "/metrics"
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	cfg, err := GetConfig(tmpfile)
+	if err != nil {
+		t.Fatalf("Expected no error for valid config, got: %v", err)
+	}
+
+	// Verify values are parsed correctly
+	if cfg.NRApiKey != "test-key-123" {
+		t.Errorf("Expected API key 'test-key-123', got: %s", cfg.NRApiKey)
+	}
+
+	if cfg.NRTimeout.Seconds() != 15 {
+		t.Errorf("Expected timeout 15s, got: %v", cfg.NRTimeout)
+	}
+
+	if len(cfg.NRMetricFilters) != 2 {
+		t.Errorf("Expected 2 metric filters, got: %d", len(cfg.NRMetricFilters))
+	}
+}
+
+func TestConfigValidation_Defaults(t *testing.T) {
+	configContent := `
+api.key: test-key-123
+api.timeout: 15s
+api.service: applications
+api.include-metric-filters:
+  - HttpDispatcher
+`
+	tmpfile := createTempConfig(t, configContent)
+	defer os.Remove(tmpfile)
+
+	cfg, err := GetConfig(tmpfile)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Check defaults are set
+	if cfg.NRApiServer != "https://api.newrelic.com" {
+		t.Errorf("Expected default API server, got: %s", cfg.NRApiServer)
+	}
+
+	if cfg.MetricPath != "/metrics" {
+		t.Errorf("Expected default metric path '/metrics', got: %s", cfg.MetricPath)
+	}
+
+	if cfg.ListenAddress != ":9126" {
+		t.Errorf("Expected default listen address ':9126', got: %s", cfg.ListenAddress)
+	}
+
+	if cfg.NRPeriod != 60 {
+		t.Errorf("Expected default period 60, got: %d", cfg.NRPeriod)
+	}
+}
+
+func createTempConfig(t *testing.T, content string) string {
+	tmpfile, err := ioutil.TempFile("", "config-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpfile.Name()
+}

--- a/newrelic_exporter.go
+++ b/newrelic_exporter.go
@@ -19,6 +19,9 @@ func main() {
 	flag.Parse()
 
 	cfg, err := config.GetConfig(configFile)
+	if err != nil {
+		log.Fatalf("Error loading config file '%s': %v", configFile, err)
+	}
 
 	api := newrelic.NewAPI(cfg)
 


### PR DESCRIPTION
This commit addresses the bug where improper configuration values would cause silent failures without proper error reporting.

Changes:
1. Added error checking in main() after config.GetConfig()
   - Previously the error was captured but never checked
   - Now the program exits with a clear error message on failure

2. Added comprehensive config validation in config package
   - Validates required fields (api.key, api.service, metric filters)
   - Checks duration fields have proper units (e.g., "15s" not "15")
   - Provides helpful error messages indicating proper format
   - Sets sensible defaults for optional fields

3. Added test suite for config validation
   - Tests for missing required fields
   - Tests for improper duration units
   - Tests for valid configurations
   - Tests for default value assignment

This ensures configuration errors are caught early with clear error messages instead of causing silent failures or panics during runtime.

Resolves: newrelic_exporter-82e (Config file silent failures)