### PR TITLE
Add Helm chart for New Relic Exporter

### DIFF
--- a/helm/newrelic-exporter/.helmignore
+++ b/helm/newrelic-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/newrelic-exporter/Chart.yaml
+++ b/helm/newrelic-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: newrelic-exporter
+description: A Helm chart for New Relic Prometheus Exporter
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - newrelic
+  - prometheus
+  - exporter
+  - monitoring
+home: https://github.com/mrf/newrelic_exporter
+sources:
+  - https://github.com/mrf/newrelic_exporter
+maintainers:
+  - name: mrf

--- a/helm/newrelic-exporter/README.md
+++ b/helm/newrelic-exporter/README.md
@@ -1,0 +1,161 @@
+# New Relic Exporter Helm Chart
+
+This Helm chart deploys the New Relic Prometheus Exporter to a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3.0+
+- A New Relic account with API access
+
+## Installing the Chart
+
+To install the chart with the release name `my-newrelic-exporter`:
+
+```bash
+helm install my-newrelic-exporter ./helm/newrelic-exporter \
+  --set newrelic.apiKey=YOUR_NEWRELIC_API_KEY \
+  --set newrelic.service=applications \
+  --set newrelic.includeMetricFilters[0]="HttpDispatcher"
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-newrelic-exporter` deployment:
+
+```bash
+helm uninstall my-newrelic-exporter
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the New Relic Exporter chart and their default values.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Image repository | `mrf/newrelic-exporter` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Image tag | `""` (uses appVersion) |
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.name` | Service account name | `""` |
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.port` | Service port | `9126` |
+| `newrelic.apiKey` | New Relic API key (required) | `""` |
+| `newrelic.existingSecret` | Use existing secret for API key | `""` |
+| `newrelic.server` | New Relic API server URL | `https://api.newrelic.com` |
+| `newrelic.period` | Data request period in seconds | `60` |
+| `newrelic.timeout` | API timeout | `15s` |
+| `newrelic.service` | New Relic service type | `""` |
+| `newrelic.includeApps` | List of applications to query | `[]` |
+| `newrelic.includeMetricFilters` | Metric filters (required) | `[]` |
+| `newrelic.includeValues` | Value filters | `[]` |
+| `web.listenAddress` | Listen address | `:9126` |
+| `web.telemetryPath` | Metrics endpoint path | `/metrics` |
+| `resources` | CPU/Memory resource requests/limits | `{}` |
+
+## Example Configuration
+
+### Basic Installation
+
+```bash
+helm install newrelic-exporter ./helm/newrelic-exporter \
+  --set newrelic.apiKey=YOUR_API_KEY \
+  --set newrelic.service=applications \
+  --set newrelic.includeMetricFilters[0]="HttpDispatcher"
+```
+
+### Using an Existing Secret
+
+Create a secret with your API key:
+
+```bash
+kubectl create secret generic newrelic-api-key --from-literal=api-key=YOUR_API_KEY
+```
+
+Install the chart using the existing secret:
+
+```bash
+helm install newrelic-exporter ./helm/newrelic-exporter \
+  --set newrelic.existingSecret=newrelic-api-key \
+  --set newrelic.service=applications \
+  --set newrelic.includeMetricFilters[0]="HttpDispatcher"
+```
+
+### Advanced Configuration with values.yaml
+
+Create a `custom-values.yaml` file:
+
+```yaml
+replicaCount: 2
+
+newrelic:
+  apiKey: YOUR_API_KEY
+  service: applications
+  period: 60
+  includeApps:
+    - "My Application"
+  includeMetricFilters:
+    - "HttpDispatcher"
+    - "Database"
+  includeValues:
+    - "average_response_time"
+    - "throughput"
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+```
+
+Install with custom values:
+
+```bash
+helm install newrelic-exporter ./helm/newrelic-exporter -f custom-values.yaml
+```
+
+## Prometheus Integration
+
+The exporter automatically adds Prometheus scrape annotations to the pod. If you're using Prometheus Operator, you can create a ServiceMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: newrelic-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: newrelic-exporter
+  endpoints:
+  - port: metrics
+    interval: 30s
+```
+
+## Troubleshooting
+
+### Check if the exporter is running
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=newrelic-exporter
+```
+
+### View exporter logs
+
+```bash
+kubectl logs -l app.kubernetes.io/name=newrelic-exporter
+```
+
+### Test metrics endpoint
+
+```bash
+kubectl port-forward svc/newrelic-exporter 9126:9126
+curl http://localhost:9126/metrics
+```
+
+## Support
+
+For issues and questions, please visit: https://github.com/mrf/newrelic_exporter/issues

--- a/helm/newrelic-exporter/templates/NOTES.txt
+++ b/helm/newrelic-exporter/templates/NOTES.txt
@@ -1,0 +1,40 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "newrelic-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "newrelic-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "newrelic-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "newrelic-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:9126 to access the metrics endpoint"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9126:$CONTAINER_PORT
+{{- end }}
+
+2. The exporter is configured to scrape metrics from New Relic API.
+   Metrics are exposed at: {{ .Values.web.telemetryPath }}
+
+3. Configure Prometheus to scrape this exporter by adding the following to your prometheus.yml:
+
+   scrape_configs:
+     - job_name: 'newrelic-exporter'
+       static_configs:
+         - targets: ['{{ include "newrelic-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}']
+
+{{- if not .Values.newrelic.apiKey }}
+{{- if not .Values.newrelic.existingSecret }}
+
+WARNING: No API key has been configured!
+Please update the deployment with your New Relic API key:
+
+  helm upgrade {{ .Release.Name }} {{ .Chart.Name }} \
+    --set newrelic.apiKey=YOUR_API_KEY \
+    --set newrelic.service=applications \
+    --set newrelic.includeMetricFilters[0]="your-metric-filter"
+
+{{- end }}
+{{- end }}

--- a/helm/newrelic-exporter/templates/_helpers.tpl
+++ b/helm/newrelic-exporter/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "newrelic-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "newrelic-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "newrelic-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "newrelic-exporter.labels" -}}
+helm.sh/chart: {{ include "newrelic-exporter.chart" . }}
+{{ include "newrelic-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "newrelic-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "newrelic-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "newrelic-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "newrelic-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "newrelic-exporter.secretName" -}}
+{{- if .Values.newrelic.existingSecret }}
+{{- .Values.newrelic.existingSecret }}
+{{- else }}
+{{- include "newrelic-exporter.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/newrelic-exporter/templates/configmap.yaml
+++ b/helm/newrelic-exporter/templates/configmap.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "newrelic-exporter.fullname" . }}
+  labels:
+    {{- include "newrelic-exporter.labels" . | nindent 4 }}
+data:
+  newrelic_exporter.yml: |
+    # API location
+    api.server: {{ .Values.newrelic.server }}
+
+    # Period of data to request, in seconds
+    api.period: {{ .Values.newrelic.period }}
+
+    # Period of time to wait for an API response
+    api.timeout: {{ .Values.newrelic.timeout }}
+
+    {{- if .Values.newrelic.service }}
+    # Name of NewRelic service to acquire metrics from
+    api.service: {{ .Values.newrelic.service }}
+    {{- end }}
+
+    # Time to cache application list
+    api.apps-list-cache-time: {{ .Values.newrelic.appsListCacheTime }}
+
+    # Time to cache metric names list
+    api.metric-names-cache-time: {{ .Values.newrelic.metricNamesCacheTime }}
+
+    {{- if .Values.newrelic.includeApps }}
+    # Filter available applications
+    api.include-apps:
+    {{- range .Values.newrelic.includeApps }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.newrelic.includeMetricFilters }}
+    # List of filters for metric names
+    api.include-metric-filters:
+    {{- range .Values.newrelic.includeMetricFilters }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.newrelic.includeValues }}
+    # List of value names to collect
+    api.include-values:
+    {{- range .Values.newrelic.includeValues }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
+
+    # Address to listen on for web interface and telemetry
+    web.listen-address: {{ .Values.web.listenAddress | quote }}
+
+    # Path under which to expose metrics
+    web.telemetry-path: {{ .Values.web.telemetryPath | quote }}
+
+    {{- if .Values.debug.proxyAddress }}
+    # Debugging proxy address
+    debug.proxy-address: {{ .Values.debug.proxyAddress | quote }}
+    {{- end }}

--- a/helm/newrelic-exporter/templates/deployment.yaml
+++ b/helm/newrelic-exporter/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "newrelic-exporter.fullname" . }}
+  labels:
+    {{- include "newrelic-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "newrelic-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "newrelic-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "newrelic-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - --config=/etc/newrelic-exporter/newrelic_exporter.yml
+        env:
+        - name: API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "newrelic-exporter.secretName" . }}
+              key: api-key
+        ports:
+        - name: metrics
+          containerPort: 9126
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.web.telemetryPath }}
+            port: metrics
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.web.telemetryPath }}
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/newrelic-exporter
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "newrelic-exporter.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/newrelic-exporter/templates/secret.yaml
+++ b/helm/newrelic-exporter/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.newrelic.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "newrelic-exporter.fullname" . }}
+  labels:
+    {{- include "newrelic-exporter.labels" . | nindent 4 }}
+type: Opaque
+data:
+  api-key: {{ .Values.newrelic.apiKey | b64enc | quote }}
+{{- end }}

--- a/helm/newrelic-exporter/templates/service.yaml
+++ b/helm/newrelic-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "newrelic-exporter.fullname" . }}
+  labels:
+    {{- include "newrelic-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "newrelic-exporter.selectorLabels" . | nindent 4 }}

--- a/helm/newrelic-exporter/templates/serviceaccount.yaml
+++ b/helm/newrelic-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "newrelic-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "newrelic-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/newrelic-exporter/values.yaml
+++ b/helm/newrelic-exporter/values.yaml
@@ -1,0 +1,107 @@
+# Default values for newrelic-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: mrf/newrelic-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9126"
+  prometheus.io/path: "/metrics"
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9126
+  targetPort: 9126
+  annotations: {}
+
+# New Relic API configuration
+newrelic:
+  # API key (required) - can be set via existingSecret
+  apiKey: ""
+
+  # Use an existing secret for API key
+  # The secret should have a key named 'api-key'
+  existingSecret: ""
+
+  # API server URL
+  server: "https://api.newrelic.com"
+
+  # Period of data to request, in seconds
+  period: 60
+
+  # API timeout
+  timeout: "15s"
+
+  # New Relic service to query (applications, mobile, etc)
+  service: ""
+
+  # Cache times
+  appsListCacheTime: "1h"
+  metricNamesCacheTime: "1h"
+
+  # Filter available applications (optional)
+  includeApps: []
+
+  # Metric filters (required) - at least one should be present
+  includeMetricFilters: []
+
+  # Value filters (optional)
+  includeValues: []
+
+# Web server configuration
+web:
+  listenAddress: ":9126"
+  telemetryPath: "/metrics"
+
+# Debug configuration
+debug:
+  proxyAddress: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This commit adds a complete Helm chart for deploying the New Relic Prometheus Exporter to Kubernetes clusters.

Features:
- Full Kubernetes deployment with configurable replicas
- Service for metrics exposure
- ConfigMap for exporter configuration
- Secret management for API keys
- ServiceAccount with RBAC support
- Prometheus scrape annotations
- Comprehensive values.yaml with sensible defaults
- Detailed README with installation and usage instructions

The chart supports:
- Custom New Relic API configuration
- Resource limits and requests
- Pod/node affinity and tolerations
- Existing secret usage for API keys
- Configurable metric filters and application filters

Resolves: newrelic_exporter-2xl (Helm chart)