### PR TITLE
Config Defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"fmt"
 	"github.com/prometheus/log"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"os"
 	"time"
 )
 
@@ -33,19 +35,226 @@ type Application struct {
 	Name string `yaml:"name"`
 }
 
+// Default configuration values
+const (
+	DefaultAPIServer            = "https://api.newrelic.com"
+	DefaultPeriod               = 60
+	DefaultTimeout              = 15 * time.Second
+	DefaultAppListCacheTime     = 1 * time.Hour
+	DefaultMetricNamesCacheTime = 1 * time.Hour
+	DefaultListenAddress        = ":9126"
+	DefaultMetricPath           = "/metrics"
+)
+
+// GetConfig loads configuration from a file and applies defaults
 func GetConfig(path string) (Config, error) {
-	config := Config{}
+	// Start with defaults
+	config := NewDefaultConfig()
+
 	configSource, err := ioutil.ReadFile(path)
 	if err != nil {
-		return config, err
+		return config, fmt.Errorf("failed to read config file: %w", err)
 	}
 
+	// Unmarshal will override defaults with user-provided values
 	err = yaml.Unmarshal(configSource, &config)
 	if err != nil {
-		return config, err
+		return config, fmt.Errorf("failed to parse YAML config: %w", err)
 	}
 
-	log.Debugf("Config loaded: %v", config)
+	// Apply defaults for any values still unset
+	config.ApplyDefaults()
 
-	return config, err
+	// Validate the final configuration
+	err = config.Validate()
+	if err != nil {
+		return config, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	log.Debugf("Config loaded successfully with defaults applied: %v", config)
+
+	return config, nil
+}
+
+// NewDefaultConfig creates a new Config with all default values set
+func NewDefaultConfig() Config {
+	return Config{
+		NRApiServer:            DefaultAPIServer,
+		NRPeriod:               DefaultPeriod,
+		NRTimeout:              DefaultTimeout,
+		NRAppListCacheTime:     DefaultAppListCacheTime,
+		NRMetricNamesCacheTime: DefaultMetricNamesCacheTime,
+		ListenAddress:          DefaultListenAddress,
+		MetricPath:             DefaultMetricPath,
+		NRApps:                 make([]Application, 0),
+		NRMetricFilters:        make([]string, 0),
+		NRValueFilters:         make([]string, 0),
+	}
+}
+
+// ApplyDefaults sets default values for any unset configuration fields
+func (c *Config) ApplyDefaults() {
+	if c.NRApiServer == "" {
+		c.NRApiServer = DefaultAPIServer
+		log.Debugf("Applied default API server: %s", DefaultAPIServer)
+	}
+
+	if c.NRPeriod == 0 {
+		c.NRPeriod = DefaultPeriod
+		log.Debugf("Applied default period: %d seconds", DefaultPeriod)
+	}
+
+	if c.NRTimeout == 0 {
+		c.NRTimeout = DefaultTimeout
+		log.Debugf("Applied default timeout: %v", DefaultTimeout)
+	}
+
+	if c.NRAppListCacheTime == 0 {
+		c.NRAppListCacheTime = DefaultAppListCacheTime
+		log.Debugf("Applied default app list cache time: %v", DefaultAppListCacheTime)
+	}
+
+	if c.NRMetricNamesCacheTime == 0 {
+		c.NRMetricNamesCacheTime = DefaultMetricNamesCacheTime
+		log.Debugf("Applied default metric names cache time: %v", DefaultMetricNamesCacheTime)
+	}
+
+	if c.ListenAddress == "" {
+		c.ListenAddress = DefaultListenAddress
+		log.Debugf("Applied default listen address: %s", DefaultListenAddress)
+	}
+
+	if c.MetricPath == "" {
+		c.MetricPath = DefaultMetricPath
+		log.Debugf("Applied default metric path: %s", DefaultMetricPath)
+	}
+
+	// Initialize empty slices if nil
+	if c.NRApps == nil {
+		c.NRApps = make([]Application, 0)
+	}
+
+	if c.NRMetricFilters == nil {
+		c.NRMetricFilters = make([]string, 0)
+	}
+
+	if c.NRValueFilters == nil {
+		c.NRValueFilters = make([]string, 0)
+	}
+}
+
+// Validate checks if the configuration is valid and provides helpful error messages
+func (c *Config) Validate() error {
+	// Check required fields
+	if c.NRApiKey == "" {
+		return fmt.Errorf("api.key is required but not set")
+	}
+
+	if c.NRService == "" {
+		return fmt.Errorf("api.service is required but not set (e.g., 'applications', 'mobile')")
+	}
+
+	if len(c.NRMetricFilters) == 0 {
+		return fmt.Errorf("api.include-metric-filters is required but empty - at least one metric filter must be specified")
+	}
+
+	// Warn about potentially incorrect duration values
+	if c.NRTimeout < time.Second {
+		log.Warnf("api.timeout is set to %v which is less than 1 second - this may be too short for API requests", c.NRTimeout)
+	}
+
+	return nil
+}
+
+// WriteDefaultConfig writes a configuration file with all default values and comments
+func WriteDefaultConfig(path string) error {
+	defaultConfig := `# New Relic Exporter Configuration with Defaults
+# All values shown are the defaults that will be used if not specified
+
+# REQUIRED: Your New Relic API key
+api.key: YOUR_API_KEY_HERE
+
+# API server (default: https://api.newrelic.com)
+api.server: https://api.newrelic.com
+
+# Data request period in seconds (default: 60)
+api.period: 60
+
+# API request timeout (default: 15s)
+# IMPORTANT: Must include time unit (s, m, h)
+api.timeout: 15s
+
+# REQUIRED: New Relic service type
+# Common values: applications, mobile, servers, plugins
+api.service: applications
+
+# Application list cache duration (default: 1h)
+# Set to 0 to disable caching
+api.apps-list-cache-time: 1h
+
+# Metric names cache duration (default: 1h)
+# Set to 0 to disable caching
+api.metric-names-cache-time: 1h
+
+# Filter specific applications (optional, default: all applications)
+# api.include-apps:
+#   - name: "My Application"
+#   - id: 123456
+
+# REQUIRED: Metric filters (at least one required)
+# Common filters: HttpDispatcher, Database, External, Apdex, Memory, CPU
+api.include-metric-filters:
+  - HttpDispatcher
+  - Database
+
+# Value filters (optional, default: all values)
+# api.include-values:
+#   - average_response_time
+#   - throughput
+
+# Web server listen address (default: :9126)
+web.listen-address: ":9126"
+
+# Metrics endpoint path (default: /metrics)
+web.telemetry-path: "/metrics"
+
+# Debug proxy address (optional, default: none)
+# debug.proxy-address: "http://localhost:8888"
+`
+
+	err := ioutil.WriteFile(path, []byte(defaultConfig), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write default config: %w", err)
+	}
+
+	log.Infof("Default configuration written to: %s", path)
+	return nil
+}
+
+// PrintDefaults prints all default values to stdout
+func PrintDefaults() {
+	fmt.Println("Default Configuration Values:")
+	fmt.Printf("  api.server: %s\n", DefaultAPIServer)
+	fmt.Printf("  api.period: %d seconds\n", DefaultPeriod)
+	fmt.Printf("  api.timeout: %v\n", DefaultTimeout)
+	fmt.Printf("  api.apps-list-cache-time: %v\n", DefaultAppListCacheTime)
+	fmt.Printf("  api.metric-names-cache-time: %v\n", DefaultMetricNamesCacheTime)
+	fmt.Printf("  web.listen-address: %s\n", DefaultListenAddress)
+	fmt.Printf("  web.telemetry-path: %s\n", DefaultMetricPath)
+	fmt.Println("\nRequired fields (no defaults):")
+	fmt.Println("  api.key - Your New Relic API key")
+	fmt.Println("  api.service - Service type (e.g., applications, mobile)")
+	fmt.Println("  api.include-metric-filters - At least one metric filter")
+}
+
+// GetConfigOrDefault attempts to load config from file, or returns defaults if file doesn't exist
+func GetConfigOrDefault(path string) (Config, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Warnf("Config file not found at %s, using defaults", path)
+		config := NewDefaultConfig()
+		config.ApplyDefaults()
+		return config, nil
+	}
+
+	return GetConfig(path)
 }

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -1,0 +1,331 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDefaultConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+	}{
+		{"DefaultAPIServer", DefaultAPIServer, "https://api.newrelic.com"},
+		{"DefaultPeriod", DefaultPeriod, 60},
+		{"DefaultTimeout", DefaultTimeout, 15 * time.Second},
+		{"DefaultAppListCacheTime", DefaultAppListCacheTime, 1 * time.Hour},
+		{"DefaultMetricNamesCacheTime", DefaultMetricNamesCacheTime, 1 * time.Hour},
+		{"DefaultListenAddress", DefaultListenAddress, ":9126"},
+		{"DefaultMetricPath", DefaultMetricPath, "/metrics"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != tt.expected {
+				t.Errorf("%s = %v, want %v", tt.name, tt.value, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	cfg := NewDefaultConfig()
+
+	if cfg.NRApiServer != DefaultAPIServer {
+		t.Errorf("Expected API server %s, got %s", DefaultAPIServer, cfg.NRApiServer)
+	}
+
+	if cfg.NRPeriod != DefaultPeriod {
+		t.Errorf("Expected period %d, got %d", DefaultPeriod, cfg.NRPeriod)
+	}
+
+	if cfg.NRTimeout != DefaultTimeout {
+		t.Errorf("Expected timeout %v, got %v", DefaultTimeout, cfg.NRTimeout)
+	}
+
+	if cfg.NRAppListCacheTime != DefaultAppListCacheTime {
+		t.Errorf("Expected app list cache time %v, got %v", DefaultAppListCacheTime, cfg.NRAppListCacheTime)
+	}
+
+	if cfg.NRMetricNamesCacheTime != DefaultMetricNamesCacheTime {
+		t.Errorf("Expected metric names cache time %v, got %v", DefaultMetricNamesCacheTime, cfg.NRMetricNamesCacheTime)
+	}
+
+	if cfg.ListenAddress != DefaultListenAddress {
+		t.Errorf("Expected listen address %s, got %s", DefaultListenAddress, cfg.ListenAddress)
+	}
+
+	if cfg.MetricPath != DefaultMetricPath {
+		t.Errorf("Expected metric path %s, got %s", DefaultMetricPath, cfg.MetricPath)
+	}
+
+	// Check slices are initialized
+	if cfg.NRApps == nil {
+		t.Error("NRApps should be initialized, got nil")
+	}
+
+	if cfg.NRMetricFilters == nil {
+		t.Error("NRMetricFilters should be initialized, got nil")
+	}
+
+	if cfg.NRValueFilters == nil {
+		t.Error("NRValueFilters should be initialized, got nil")
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	// Test with empty config
+	cfg := Config{}
+	cfg.ApplyDefaults()
+
+	if cfg.NRApiServer != DefaultAPIServer {
+		t.Errorf("Expected default API server, got %s", cfg.NRApiServer)
+	}
+
+	if cfg.NRPeriod != DefaultPeriod {
+		t.Errorf("Expected default period, got %d", cfg.NRPeriod)
+	}
+
+	if cfg.ListenAddress != DefaultListenAddress {
+		t.Errorf("Expected default listen address, got %s", cfg.ListenAddress)
+	}
+}
+
+func TestApplyDefaultsPreservesUserValues(t *testing.T) {
+	// Test that user-provided values are not overridden
+	cfg := Config{
+		NRApiServer:   "https://custom.api.com",
+		NRPeriod:      120,
+		ListenAddress: ":8080",
+	}
+
+	cfg.ApplyDefaults()
+
+	if cfg.NRApiServer != "https://custom.api.com" {
+		t.Error("ApplyDefaults should not override user-provided API server")
+	}
+
+	if cfg.NRPeriod != 120 {
+		t.Error("ApplyDefaults should not override user-provided period")
+	}
+
+	if cfg.ListenAddress != ":8080" {
+		t.Error("ApplyDefaults should not override user-provided listen address")
+	}
+}
+
+func TestGetConfigWithDefaults(t *testing.T) {
+	// Create a minimal config file
+	configContent := `
+api.key: test-api-key
+api.service: applications
+api.timeout: 15s
+api.include-metric-filters:
+  - HttpDispatcher
+`
+
+	tmpfile, err := ioutil.TempFile("", "config-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := GetConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("GetConfig failed: %v", err)
+	}
+
+	// Check required fields were set
+	if cfg.NRApiKey != "test-api-key" {
+		t.Error("API key not set from config")
+	}
+
+	if cfg.NRService != "applications" {
+		t.Error("Service not set from config")
+	}
+
+	// Check defaults were applied
+	if cfg.NRApiServer != DefaultAPIServer {
+		t.Errorf("Expected default API server, got %s", cfg.NRApiServer)
+	}
+
+	if cfg.NRPeriod != DefaultPeriod {
+		t.Errorf("Expected default period, got %d", cfg.NRPeriod)
+	}
+
+	if cfg.ListenAddress != DefaultListenAddress {
+		t.Errorf("Expected default listen address, got %s", cfg.ListenAddress)
+	}
+
+	if cfg.MetricPath != DefaultMetricPath {
+		t.Errorf("Expected default metric path, got %s", cfg.MetricPath)
+	}
+}
+
+func TestGetConfigOverridesDefaults(t *testing.T) {
+	// Create a config with custom values
+	configContent := `
+api.key: test-api-key
+api.server: https://custom.api.com
+api.period: 120
+api.timeout: 30s
+api.service: applications
+api.include-metric-filters:
+  - HttpDispatcher
+web.listen-address: ":8080"
+web.telemetry-path: "/custom-metrics"
+`
+
+	tmpfile, err := ioutil.TempFile("", "config-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := GetConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("GetConfig failed: %v", err)
+	}
+
+	// Check custom values were used instead of defaults
+	if cfg.NRApiServer != "https://custom.api.com" {
+		t.Errorf("Expected custom API server, got %s", cfg.NRApiServer)
+	}
+
+	if cfg.NRPeriod != 120 {
+		t.Errorf("Expected custom period 120, got %d", cfg.NRPeriod)
+	}
+
+	if cfg.ListenAddress != ":8080" {
+		t.Errorf("Expected custom listen address, got %s", cfg.ListenAddress)
+	}
+
+	if cfg.MetricPath != "/custom-metrics" {
+		t.Errorf("Expected custom metric path, got %s", cfg.MetricPath)
+	}
+}
+
+func TestWriteDefaultConfig(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "default-config-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+
+	err = WriteDefaultConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("WriteDefaultConfig failed: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(tmpfile.Name()); os.IsNotExist(err) {
+		t.Error("Default config file was not created")
+	}
+
+	// Read and verify content
+	content, err := ioutil.ReadFile(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contentStr := string(content)
+
+	// Check that file contains expected elements
+	expectedStrings := []string{
+		"api.key:",
+		"api.server:",
+		"api.timeout:",
+		"api.service:",
+		"api.include-metric-filters:",
+		"web.listen-address:",
+		"web.telemetry-path:",
+	}
+
+	for _, expected := range expectedStrings {
+		if !contains(contentStr, expected) {
+			t.Errorf("Default config should contain '%s'", expected)
+		}
+	}
+}
+
+func TestGetConfigOrDefaultWithExistingFile(t *testing.T) {
+	configContent := `
+api.key: test-key
+api.service: applications
+api.timeout: 15s
+api.include-metric-filters:
+  - HttpDispatcher
+`
+
+	tmpfile, err := ioutil.TempFile("", "config-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(configContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := GetConfigOrDefault(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("GetConfigOrDefault failed: %v", err)
+	}
+
+	if cfg.NRApiKey != "test-key" {
+		t.Error("Config should be loaded from file")
+	}
+}
+
+func TestGetConfigOrDefaultWithMissingFile(t *testing.T) {
+	// Use a path that doesn't exist
+	cfg, err := GetConfigOrDefault("/tmp/nonexistent-config-file.yml")
+
+	// Should not error, should return defaults
+	if err != nil {
+		t.Errorf("GetConfigOrDefault should not error on missing file, got: %v", err)
+	}
+
+	// Should have defaults
+	if cfg.NRApiServer != DefaultAPIServer {
+		t.Error("Should have default API server")
+	}
+
+	if cfg.ListenAddress != DefaultListenAddress {
+		t.Error("Should have default listen address")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/newrelic_exporter.go
+++ b/newrelic_exporter.go
@@ -14,11 +14,37 @@ import (
 
 func main() {
 	var configFile string
+	var printDefaults bool
+	var generateConfig string
 
-	flag.StringVar(&configFile, "config", "newrelic_exporter.yml", "Config file path. Defaults to 'newrelic_exporter.yml'")
+	flag.StringVar(&configFile, "config", "newrelic_exporter.yml", "Config file path")
+	flag.BoolVar(&printDefaults, "print-defaults", false, "Print default configuration values and exit")
+	flag.StringVar(&generateConfig, "generate-config", "", "Generate a default configuration file at the specified path and exit")
 	flag.Parse()
 
+	// Handle utility flags
+	if printDefaults {
+		config.PrintDefaults()
+		return
+	}
+
+	if generateConfig != "" {
+		err := config.WriteDefaultConfig(generateConfig)
+		if err != nil {
+			log.Fatalf("Failed to generate config: %v", err)
+		}
+		log.Infof("Default configuration written to: %s", generateConfig)
+		log.Info("Please edit the file to set your API key and other required fields")
+		return
+	}
+
+	// Load configuration with defaults
 	cfg, err := config.GetConfig(configFile)
+	if err != nil {
+		log.Fatalf("Error loading config file '%s': %v", configFile, err)
+	}
+
+	log.Infof("Configuration loaded successfully from %s", configFile)
 
 	api := newrelic.NewAPI(cfg)
 


### PR DESCRIPTION
This commit adds a robust default configuration system that makes the exporter easier to configure and use.

Features:

Default Configuration Constants

DefaultAPIServer: https://api.newrelic.com/
DefaultPeriod: 60 seconds
DefaultTimeout: 15 seconds
DefaultAppListCacheTime: 1 hour
DefaultMetricNamesCacheTime: 1 hour
DefaultListenAddress: :9126
DefaultMetricPath: /metrics
NewDefaultConfig() Function

Creates a Config with all defaults pre-populated
Initializes empty slices to prevent nil pointer issues
ApplyDefaults() Method

Automatically applies defaults for unset fields
Preserves user-provided values
Logs when defaults are applied (debug level)
Enhanced GetConfig()

Starts with defaults
Overlays user configuration
Re-applies defaults for any still-unset fields
Validates final configuration
Validation

Checks required fields (api.key, api.service, metric filters)
Warns about potentially problematic values
Provides helpful error messages
Utility Functions

WriteDefaultConfig(path) - Generates config file with defaults
PrintDefaults() - Shows all default values
GetConfigOrDefault(path) - Loads config or uses defaults
New Command-Line Flags

--print-defaults: Display all default values and exit
--generate-config : Create default config file and exit
Comprehensive Tests (defaults_test.go)

Tests for all default constants
Tests for NewDefaultConfig()
Tests for ApplyDefaults() behavior
Tests that user values are preserved
Tests for GetConfig() with partial configs
Tests for WriteDefaultConfig()
Tests for GetConfigOrDefault()
Usage Examples:

Print all defaults

./newrelic_exporter --print-defaults

Generate a config file with defaults

./newrelic_exporter --generate-config myconfig.yml

Run with minimal config (others use defaults)

./newrelic_exporter --config minimal-config.yml

Benefits:

Users can provide minimal configurations
All optional settings have sensible defaults
Easy to discover what can be configured
Configuration errors are caught early
Reduces barrier to entry for new users
Resolves: newrelic_exporter-git (Config File Defaults)